### PR TITLE
Add Quotes around paths. Resolves issues when a space is in user path name

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -122,8 +122,8 @@ function listen(port) {
             '/OU=dev/CN=localhost/emailAddress=test@test.com"', function(err) {
 
             handleCreatingCertError(err);
-            err || exec('openssl x509 -req -days 1000 -in "' + defaultCSRPath + '" -signkey ' +
-              defaultKeyPath + ' -out "' + defaultCertPath + '"', function(err) {
+            err || exec('openssl x509 -req -days 1000 -in "' + defaultCSRPath + '" -signkey "' +
+              defaultKeyPath + '" -out "' + defaultCertPath + '"', function(err) {
 
               handleCreatingCertError(err);
               err || createServer();

--- a/bin/http-server
+++ b/bin/http-server
@@ -117,7 +117,7 @@ function listen(port) {
         log('Generating and using default cert and key files in: '.yellow + __dirname.cyan);
         exec('openssl genrsa -out ' + defaultKeyPath + ' 4096', function(err) {
           handleCreatingCertError(err);
-          err || exec('openssl req -new -key ' + defaultKeyPath + ' -out ' + defaultCSRPath +
+          err || exec('openssl req -new -key "' + defaultKeyPath + '" -out ' + defaultCSRPath +
             ' -subj "/C=US/ST=California/L=San Francisco/O=Local-Company' +
             '/OU=dev/CN=localhost/emailAddress=test@test.com"', function(err) {
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -115,14 +115,14 @@ function listen(port) {
 
       if (!fs.existsSync(defaultCertPath)) {
         log('Generating and using default cert and key files in: '.yellow + __dirname.cyan);
-        exec('openssl genrsa -out ' + defaultKeyPath + ' 4096', function(err) {
+        exec('openssl genrsa -out "' + defaultKeyPath + '" 4096', function(err) {
           handleCreatingCertError(err);
           err || exec('openssl req -new -key "' + defaultKeyPath + '" -out ' + defaultCSRPath +
             ' -subj "/C=US/ST=California/L=San Francisco/O=Local-Company' +
             '/OU=dev/CN=localhost/emailAddress=test@test.com"', function(err) {
 
             handleCreatingCertError(err);
-            err || exec('openssl x509 -req -days 1000 -in ' + defaultCSRPath + ' -signkey ' +
+            err || exec('openssl x509 -req -days 1000 -in "' + defaultCSRPath + '" -signkey ' +
               defaultKeyPath + ' -out ' + defaultCertPath, function(err) {
 
               handleCreatingCertError(err);

--- a/bin/http-server
+++ b/bin/http-server
@@ -123,7 +123,7 @@ function listen(port) {
 
             handleCreatingCertError(err);
             err || exec('openssl x509 -req -days 1000 -in "' + defaultCSRPath + '" -signkey ' +
-              defaultKeyPath + ' -out ' + defaultCertPath, function(err) {
+              defaultKeyPath + ' -out "' + defaultCertPath + '"', function(err) {
 
               handleCreatingCertError(err);
               err || createServer();

--- a/bin/http-server
+++ b/bin/http-server
@@ -117,8 +117,8 @@ function listen(port) {
         log('Generating and using default cert and key files in: '.yellow + __dirname.cyan);
         exec('openssl genrsa -out "' + defaultKeyPath + '" 4096', function(err) {
           handleCreatingCertError(err);
-          err || exec('openssl req -new -key "' + defaultKeyPath + '" -out ' + defaultCSRPath +
-            ' -subj "/C=US/ST=California/L=San Francisco/O=Local-Company' +
+          err || exec('openssl req -new -key "' + defaultKeyPath + '" -out "' + defaultCSRPath +
+            '" -subj "/C=US/ST=California/L=San Francisco/O=Local-Company' +
             '/OU=dev/CN=localhost/emailAddress=test@test.com"', function(err) {
 
             handleCreatingCertError(err);


### PR DESCRIPTION
I added quotes around the paths. The command line was throwing errors because there is spaces in the user path on one of my machines. This fixes the issue.